### PR TITLE
End study for custom reason

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -262,6 +262,23 @@ class Study extends EventTarget {
         die();
       }).bind(this)
     )
+    this.on(
+      "uninstall-custom-reason", (function (reason) {
+        prefSvc.get('shield.debug') && console.log("uninstall-custom-reason", this.states);
+        this.states.push("uninstall-custom-reason");
+        if (this.flags.dying) {
+          this.final();
+          return;
+        }
+        this.flags.dying = true;
+        this.report(merge({}, telemetrySubset(this.config), {study_state: reason}), "shield");
+        let that = this;
+        generateTelemetryIdIfNeeded().then(()=>that.showSurvey(reason));
+        try {this.cleanup()} catch (err) {/*ok*/} finally { /*ok*/ }
+        this.final();
+        die();
+      }).bind(this)
+    )
   }
 
   get state () {
@@ -351,6 +368,10 @@ class Study extends EventTarget {
       case "downgrade":
         emit(this, "change", "normal-shutdown")
         break;
+
+      // custom, study-specific reason for ending study
+      default:
+        emit(this, "uninstall-custom-reason", reason);
     }
     return this;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,8 +239,7 @@ class Study extends EventTarget {
           try {this.whenComplete()} catch (err) { /*ok*/ } finally { /*ok*/ }
           this.report(merge({}, telemetrySubset(this.config) ,{study_state: "end-of-study"}), "shield");
           // survey for end of study
-          let that = this;
-          generateTelemetryIdIfNeeded().then(()=>that.showSurvey("end-of-study"));
+          generateTelemetryIdIfNeeded().then(()=>this.showSurvey("end-of-study"));
           try {this.cleanup()} catch (err) {/*ok*/} finally { /*ok*/ }
           this.final();
           die();
@@ -255,8 +254,7 @@ class Study extends EventTarget {
         }
         this.flags.dying = true;
         this.report(merge({}, telemetrySubset(this.config), {study_state: "user-ended-study"}), "shield");
-        let that = this;
-        generateTelemetryIdIfNeeded().then(()=>that.showSurvey("user-ended-study"));
+        generateTelemetryIdIfNeeded().then(()=>this.showSurvey("user-ended-study"));
         try {this.cleanup()} catch (err) {/*ok*/} finally { /*ok*/ }
         this.final();
         die();
@@ -272,8 +270,7 @@ class Study extends EventTarget {
         }
         this.flags.dying = true;
         this.report(merge({}, telemetrySubset(this.config), {study_state: reason}), "shield");
-        let that = this;
-        generateTelemetryIdIfNeeded().then(()=>that.showSurvey(reason));
+        generateTelemetryIdIfNeeded().then(()=>this.showSurvey(reason));
         try {this.cleanup()} catch (err) {/*ok*/} finally { /*ok*/ }
         this.final();
         die();

--- a/test/test-shield-studies-addon-utils.js
+++ b/test/test-shield-studies-addon-utils.js
@@ -75,7 +75,8 @@ var studyInfo = {
   days: 7,
   surveyUrls: {
     'end-of-study': self.data.url("expired.html"),
-    'user-ended-study': self.data.url("uninstall.html")
+    'user-ended-study': self.data.url("uninstall.html"),
+    'custom-end-of-study': self.data.url("custom.html")
   }
 };
 
@@ -830,6 +831,40 @@ exports[`test Study states: user-uninstall-disable: call all you want, only does
     )
     expect(countTabsLike("user-ended-study"),'exactly 1 survey').to.equal(1);
     expect(countTabsLike(thisStudy.config.surveyUrls['user-ended-study']),'exactly 1 survey').to.equal(1);
+  })
+}
+
+exports[`test Study states: custom-uninstall: call all you want, only does one survey`] = function (assert) {
+  let {thisStudy, seen, R} = setupStartupTest(studyInfoCopy());
+  emit(thisStudy, "uninstall-custom-reason", "custom-end-of-study");
+  emit(thisStudy, "uninstall-custom-reason", "custom-end-of-study");
+  emit(thisStudy, "uninstall-custom-reason", "custom-end-of-study");
+  emit(thisStudy, "uninstall-custom-reason", "custom-end-of-study");
+  let wanted = {
+    reports: ["custom-end-of-study"],
+    states:  ["uninstall-custom-reason", "uninstall-custom-reason", "uninstall-custom-reason", "uninstall-custom-reason"]
+  }
+  return waitABit().then(
+  ()=> {
+    teardownStartupTest(R);
+    endsLike(
+      {
+        flags: {
+          ineligibleDie: undefined,
+          expired: undefined,
+          dying: true
+        },
+        state: "uninstall-custom-reason",
+        reports: wanted.reports,
+        states: wanted.states,
+        notUrls: [thisStudy.config.surveyUrls['end-of-study'],'end-of-study'],
+        urls: [thisStudy.config.surveyUrls['custom-end-of-study']]
+      },
+      thisStudy,
+      seen
+    )
+    expect(countTabsLike("custom-end-of-study"),'exactly 1 survey').to.equal(1);
+    expect(countTabsLike(thisStudy.config.surveyUrls['user-ended-study']),"custom-end-of-study").to.equal(1);
   })
 }
 

--- a/test/test-shield-studies-addon-utils.js
+++ b/test/test-shield-studies-addon-utils.js
@@ -767,6 +767,37 @@ exports['test cleanup: bad cleanup function wont stop uninstall'] = function (as
   )
 }
 
+exports[`test Study states: custom-uninstall shuts down, presents survey`] = function (assert) {
+  let {thisStudy, seen, R} = setupStartupTest(studyInfoCopy());
+  thisStudy.shutdown("custom-end-of-study");
+  let wanted = {
+    reports: ["custom-end-of-study"],
+    states:  ["uninstall-custom-reason"]
+  }
+  return waitABit().then(
+  ()=> {
+    teardownStartupTest(R);
+    endsLike(
+      {
+        flags: {
+          ineligibleDie: undefined,
+          expired: undefined,
+          dying: true
+        },
+        state: "uninstall-custom-reason",
+        reports: wanted.reports,
+        states: wanted.states,
+        notUrls: [thisStudy.config.surveyUrls['end-of-study'],'end-of-study'],
+        urls: [thisStudy.config.surveyUrls['custom-end-of-study']]
+      },
+      thisStudy,
+      seen
+    )
+    expect(countTabsLike("custom-end-of-study"),'exactly 1 survey').to.equal(1);
+    expect(countTabsLike(thisStudy.config.surveyUrls['user-ended-study']),"custom-end-of-study").to.equal(1);
+  })
+}
+
 
 exports[`test Study states: end-of-study: call all you want, only does one survey`] = function (assert) {
   let {thisStudy, seen, R} = setupStartupTest(studyInfoCopy());


### PR DESCRIPTION
The shutdown method can now be used to end the study with custom survey urls. Call the shutdown method with a name that matches a key in the studyConfig object's surveyUrls object. The add-on will immediately uninstall itself, log the reason to telemetry, and display the provided survey.

@groovecoder r?