### PR TITLE
Allow for no debugging messages and make StudyUtils match Config.jsm

### DIFF
--- a/src/StudyUtils.in.jsm
+++ b/src/StudyUtils.in.jsm
@@ -207,6 +207,10 @@ class StudyUtils {
     this.throwIfNotSetup("openTab");
     log.debug(url, params);
     log.debug("opening this formatted tab", url, params);
+    if (!Services.wm.getMostRecentWindow("navigator:browser").gBrowser) {
+      // Wait for the window to be opened
+      await new Promise(resolve => setTimeout(resolve, 30000));
+    }
     Services.wm.getMostRecentWindow("navigator:browser").gBrowser.addTab(url, params);
   }
   async getTelemetryId() {

--- a/src/StudyUtils.in.jsm
+++ b/src/StudyUtils.in.jsm
@@ -15,7 +15,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["URL", "crypto", "URLSearchParams"]);
 
-const log = createLog("shield-study-utils", "Debug");
+let log;
 
 // telemetry utils
 const CID = Cu.import("resource://gre/modules/ClientID.jsm", null);
@@ -189,6 +189,8 @@ class StudyUtils {
     if (!this._isSetup) throw new Error(name + ": this method can't be used until `setup` is called");
   }
   setup(config) {
+    log = createLog("shield-study-utils", config.log.studyUtils.level);
+
     log.debug("setting up!");
     jsonschema.validateOrThrow(config, schemas.studySetup);
 
@@ -227,7 +229,7 @@ class StudyUtils {
     log.debug("getting info");
     this.throwIfNotSetup("info");
     return {
-      studyName: this.config.studyName,
+      studyName: this.config.study.studyName,
       addon: this.config.addon,
       variation: this.getVariation(),
       shieldId: this.getShieldId(),
@@ -236,7 +238,7 @@ class StudyUtils {
   // TODO glind, maybe this is getter / setter?
   get telemetryConfig() {
     this.throwIfNotSetup("telemetryConfig");
-    return this.config.telemetry;
+    return this.config.study.telemetry;
   }
   firstSeen() {
     log.debug(`firstSeen`);
@@ -285,7 +287,7 @@ class StudyUtils {
     this.unsetActive();
     // TODO glind, think about reason vs fullname
     // TODO glind, think about race conditions for endings, ensure only one exit
-    const ending = this.config.endings[reason];
+    const ending = this.config.study.endings[reason];
     if (ending) {
       const {baseUrl, exactUrl} = ending;
       if (exactUrl) {
@@ -407,8 +409,8 @@ function createLog(name, levelWord) {
   Cu.import("resource://gre/modules/Log.jsm");
   var L = Log.repository.getLogger(name);
   L.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
-  L.debug("log made", name, levelWord, Log.Level[levelWord]);
   L.level = Log.Level[levelWord] || Log.Level.Debug; // should be a config / pref
+  L.debug("log made", name, levelWord, Log.Level[levelWord]);
   return L;
 }
 /** addon state change reasons */

--- a/src/schema.studySetup.json
+++ b/src/schema.studySetup.json
@@ -36,19 +36,57 @@
     }
   },
   "properties": {
-    "studyName": {
-      "$ref" : "#/definitions/idString",
-      "description": "Name of a particular study.  Usually the addon_id."
+    "study": {
+      "type": "object",
+      "properties": {
+        "studyName": {
+          "$ref": "#/definitions/idString",
+          "description": "Name of a particular study.  Usually the addon_id."
+        },
+        "endings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ending"
+          }
+        },
+        "telemetry": {
+          "type": "object",
+          "properties": {
+            "removeTestingFlag": {
+              "type": "boolean"
+            },
+            "send": {
+              "type": "boolean"
+            },
+            "onInvalid": {
+              "type": "string",
+              "enum": [
+                "throw",
+                "log"
+              ]
+            }
+          },
+          "required": [
+            "removeTestingFlag",
+            "send"
+          ]
+        }
+      },
+      "required": [
+        "studyName",
+        "endings",
+        "telemetry"
+      ]
     },
     "addon": {
       "type": "object",
       "properties": {
         "id": {
-          "$ref" : "#/definitions/idString",
+          "$ref": "#/definitions/idString",
           "description": "id of the addon."
         },
         "version": {
-          "$ref" : "#/definitions/idString",
+          "$ref": "#/definitions/idString",
           "description": "Semantic version of the addon."
         }
       },
@@ -56,40 +94,10 @@
         "id",
         "version"
       ]
-    },
-    "endings": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/ending"
-      }
-    },
-    "telemetry": {
-      "type": "object",
-      "properties": {
-        "removeTestingFlag": {
-          "type": "boolean"
-        },
-        "send": {
-          "type": "boolean"
-        },
-        "onInvalid": {
-          "type": "string",
-          "enum": [
-            "throw",
-            "log"
-          ]
-        }
-      },
-      "required": [
-        "removeTestingFlag",
-        "send"
-      ]
     }
   },
   "required": [
-    "studyName",
-    "endings",
-    "addon",
-    "telemetry"
+    "study",
+    "addon"
   ]
 }

--- a/test-addon/utils.jsm
+++ b/test-addon/utils.jsm
@@ -8,13 +8,22 @@ var EXPORTED_SYMBOLS = ["fakeSetup", "getMostRecentPingsByType"];
 
 function fakeSetup() {
   studyUtils.setup({
-    studyName: "shield-utils-test",
-    endings: {
-      "expired": {
-        "baseUrl": "http://www.example.com/?reason=expired",
-      }},
+    study: {
+      studyName: "shield-utils-test",
+      endings: {
+        "expired": {
+          "baseUrl": "http://www.example.com/?reason=expired",
+        },
+      },
+      telemetry: { send: true, removeTestingFlag: false },
+    },
+    log: {
+      // Fatal: 70, Error: 60, Warn: 50, Info: 40, Config: 30, Debug: 20, Trace: 10, All: -1,
+      studyUtils: {
+        level: "Warn",
+      },
+    },
     addon: {id: "1", version: "1"},
-    telemetry: { send: true, removeTestingFlag: false },
   });
   studyUtils.setVariation({ name: "puppers", weight: "2" });
 }

--- a/test/shield_utils_test.js
+++ b/test/shield_utils_test.js
@@ -139,11 +139,12 @@ describe("Shield Study Utils Functional Tests", function() {
     });
 
     describe("test the opening of a URL at the end of the study", function() {
-      let handles;
-
       it("should open a new tab", async() => {
-        handles = await driver.getAllWindowHandles();
-        assert(handles.length === 2); // opened a new tab
+        const newTabOpened = await driver.wait(async() => {
+          const handles = await driver.getAllWindowHandles();
+          return handles.length === 2; // opened a new tab
+        }, 3000);
+        assert(newTabOpened);
       });
 
       it("should open a new tab to the correct URL", async() => {
@@ -151,14 +152,18 @@ describe("Shield Study Utils Functional Tests", function() {
         driver.setContext(Context.CONTENT);
         // Find the new window handle.
         let newWindowHandle = null;
+        const handles = await driver.getAllWindowHandles();
         for (const handle of handles) {
           if (handle !== currentHandle) {
             newWindowHandle = handle;
           }
         }
-        await driver.switchTo().window(newWindowHandle);
-        const currentURL = await driver.getCurrentUrl();
-        assert(currentURL.startsWith("http://www.example.com/?reason=expired"));
+        const correctURLOpened = await driver.wait(async() => {
+          await driver.switchTo().window(newWindowHandle);
+          const currentURL = await driver.getCurrentUrl();
+          return currentURL.startsWith("http://www.example.com/?reason=expired");
+        });
+        assert(correctURLOpened);
       });
     });
 


### PR DESCRIPTION
Changes:
- Improved the log level setting as to avoid *any* debugging messages.
- Updated StudyUtils to match the format of Config.jsm.

The motivation behind this change was for the release of the share button study, with goal of removing debugging messages from the browser console. I also decided to update how `studyUtils.setup()` and general `config` handling works to more closely match the format of the Config.jsm file.