### PR TITLE
Remove warnings for about:config and Addon Debugger in testing

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -26,6 +26,8 @@ const FIREFOX_PREFERENCES = {
   // toolbox.
   "devtools.chrome.enabled": true,
   "devtools.debugger.remote-enabled": true,
+  "devtools.debugger.prompt-connection": false,
+  "general.warnOnAboutConfig": false
 };
 
 // useful if we need to test on a specific version of Firefox


### PR DESCRIPTION
Changing these prefs removes the connection warning prompt when using the Addon Debugger and the warning prompt when in about:config. Taken from [here](https://github.com/gregglind/57-perception-shield-study).