### PR TITLE
Release/5.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # Download and cache dependencies (update the cache keys to force a newer version)
       - restore_cache:
           keys:
-          - dependencies-and-browsers-{{ checksum "package.json" }}-20180619
+          - dependencies-and-browsers-{{ checksum "package.json" }}-20180707
 
       - run:
           name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
             - firefox-beta
             - firefox-release
             - firefox-unbranded-release
-          key: dependencies-and-browsers-{{ checksum "package.json" }}-20180619
+          key: dependencies-and-browsers-{{ checksum "package.json" }}-20180707
 
       - run:
           name: Reveal which Firefox versions are installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,10 @@ jobs:
       - store_artifacts:
           path: "test-addon/dist"
 
-      - run:
-          name: Test with Firefox Release
-          command: FIREFOX_BINARY=/home/circleci/checkout/firefox-release/firefox-bin npm run test-only
-
-      # Utils v5 does not work with Firefox Beta #200
+      # Needs signed add-on to work on branded releases
+      #- run:
+      #    name: Test with Firefox Release
+      #    command: FIREFOX_BINARY=/home/circleci/checkout/firefox-release/firefox-bin npm run test-only
       #- run:
       #    name: Test with Firefox Beta
       #    command: FIREFOX_BINARY=/home/circleci/checkout/firefox-beta/firefox-bin npm run test-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/node:latest-browsers
+        environment:
+          FIREFOX_BIN: /home/circleci/checkout/firefox-release/firefox-bin
+          FIREFOX_AURORA_BIN: /home/circleci/checkout/firefox-beta/firefox-bin
+          FIREFOX_DEVELOPER_BIN: /home/circleci/checkout/firefox-devedition/firefox-bin
+          FIREFOX_NIGHTLY_BIN: /home/circleci/checkout/firefox-nightly/firefox-bin
 
     working_directory: ~/checkout
 
@@ -69,7 +74,7 @@ jobs:
 
       - run:
           name: Test with Firefox Developer Edition
-          command: FIREFOX_BINARY=/home/circleci/checkout/firefox-devedition/firefox-bin FIREFOX_DEVELOPER_BIN=/home/circleci/checkout/firefox-devedition/firefox-bin npm run test-only
+          command: FIREFOX_BINARY=/home/circleci/checkout/firefox-devedition/firefox-bin npm run test-only
 
       - run:
           name: Test with Firefox Nightly

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,8 +3,8 @@ dist/
 webExtensionApis/study/api.js
 package-lock.json
 # do not lint/format bundled util libraries
-examples/test-addon/src/privileged/prefs/
-examples/test-addon/src/privileged/study/
+test-addon/src/privileged/prefs/
+test-addon/src/privileged/study/
 # makes sure that eslintrc.js gets linted/formatted
 !.eslintrc.js
 # don't lint/format code the directory where get-firefox stores the Firefox binaries

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Allows writing [Shield and Pioneer](https://wiki.mozilla.org/Firefox/Shield/Shie
 
       Notice the `experiment_apis` section. This maps `browser.study` to the privileged api code. (See details below)
 
-    * [`study.js`](./examples/small-study/src/study.js)
+    * [`studySetup.js`](./examples/small-study/src/studySetup.js)
 
       Construct a `studySetup` usable by `browser.study.setup`
 
-    * [`background.js`](./examples/small-study/src/backaround.js)
+    * [`background.js`](./examples/small-study/src/background.js)
 
       Using the `browser.study` api within a small instrumented feature.
 
@@ -234,30 +234,24 @@ Goal: Use `webdriver` to exercise the `browser.study` API to prove correctness.
 4.  Do tests:
 
     1.  `mocha` test runner uses files in `testUtils/` to
-    2.  install the addon (using `webdriver`)
-    3.  switch context to the panel, so that we can exercise `browser.study`. The function that does this: `setupWebDriver`
+    2.  Install the addon (using `webdriver`)
+    3.  Switch context to the panel, so that we can exercise `browser.study`. The function that does this: `setupWebDriver`
     4.  Run all tests. Most API tests are at: `test/functional/browser.study.api.js`
     5.  Most tests are of this `Selenium`/`WebDriver`/`GeckoDriver` form:
 
         * run some async code in the panel context using `addonExec`
         * in that code, exercise the `browser.study` api.
-        * callback with the results, `study.getInfo`, and/or `browser.studyDebug.getInternals()` as needful.
+        * callback with the results of `browser.study.setup()`, and/or `browser.studyDebug.getInternals()` as necessary.
         * use `node` `assert` to check the called back result.
 
 **Note**: `browser.studyDebug.getInternals()` gets internals of the `studyUtils` singleton as needful. `browser.studyDebug` also allows other manipulation of the studyUtils singleton, for use by tests, and to induce states and reactions.
-
-## Known issues
-
-* Utils v5.0.0-v5.0.1 does not work with Firefox Beta (#200)
-
-In general, see https://github.com/mozilla/shield-studies-addon-utils/issues
 
 ## FAQ
 
 * What's the deal with Webpack?
 
-  * we want `api.js` to be one file, for ease of use by study authors
-  * we want the source to be broken up into logical pieces
+  * We want `api.js` to be one file, for ease of use by study authors
+  * We want the source to be broken up into logical pieces
   * Firefox doens't come with a usable JSONSchema library (`Schema.jsm` isn't very usable.
   * We want Jsonschema validation to guard args, and to send Telemetry
   * we use `webpack` to bundle src and AJV (jsonschema) into `api.js`
@@ -309,12 +303,12 @@ In general, see https://github.com/mozilla/shield-studies-addon-utils/issues
 
   * studies end when
 
-    1.  you call `browser.endStudy`
-    2.  studies hit their `expire.days` after `firstRunTimestamp
+    1.  you call `browser.study.endStudy`
+    2.  studies hit their `expire.days` after `firstRunTimestamp`
     3.  user disables the study from `about:addons`
-    4.  Normandy revokes a study (which looks like `user-disable, see #194)
+    4.  Normandy revokes a study (which looks like `user-disable`, see #194)
 
-  * In all cases (excect the 'user-disable'), the webExtension will see an `onEndStudy` if registered. It's up to the add-on to then open all endingUrls, and actually uninstall the study.
+  * In all cases (except the 'user-disable', see #194), the webExtension will see an `onEndStudy` if registered. It's up to the add-on to then open all endingUrls, and actually uninstall the study.
 
 - QA
 
@@ -332,6 +326,7 @@ In general, see https://github.com/mozilla/shield-studies-addon-utils/issues
   * `KEEPOPEN=1 npm run test` keeps Firefox open
   * `SKIPLINT=1 npm run test` skips linting
   * `npm run test-only` skips build steps.
+* Read [./docs/development-on-the-utils.md](./docs/development-on-the-utils.md) for more in-depth development documentation.
 
 ## History of major versions
 

--- a/examples/small-study/src/studySetup.js
+++ b/examples/small-study/src/studySetup.js
@@ -42,9 +42,7 @@ const baseStudySetup = {
       ],
     },
     ineligible: {
-      baseUrls: [
-        "https://qsurvey.mozilla.com/s3/Shield-Study-Example-Survey/?reason=ineligible",
-      ],
+      baseUrls: [],
     },
     expired: {
       baseUrls: [

--- a/examples/small-study/src/studySetup.js
+++ b/examples/small-study/src/studySetup.js
@@ -104,8 +104,8 @@ const baseStudySetup = {
  */
 async function cachingFirstRunShouldAllowEnroll() {
   // Cached answer.  Used on 2nd run
-  let allowed = await browser.storage.local.get("allowEnroll");
-  if (allowed.allowEnroll === true) return true;
+  let allowed = await browser.storage.local.get("allowedEnrollOnFirstRun");
+  if (allowed.allowedEnrollOnFirstRun === true) return true;
 
   /*
   First run, we must calculate the answer.
@@ -116,7 +116,7 @@ async function cachingFirstRunShouldAllowEnroll() {
   allowed = true;
 
   // cache the answer
-  await browser.storage.local.set({ allowEnroll: allowed });
+  await browser.storage.local.set({ allowedEnrollOnFirstRun: allowed });
   return allowed;
 }
 

--- a/examples/small-study/src/studySetup.js
+++ b/examples/small-study/src/studySetup.js
@@ -105,7 +105,7 @@ const baseStudySetup = {
 async function cachingFirstRunShouldAllowEnroll() {
   // Cached answer.  Used on 2nd run
   let allowed = await browser.storage.local.get("allowEnroll");
-  if (allowed) return true;
+  if (allowed.allowEnroll === true) return true;
 
   /*
   First run, we must calculate the answer.

--- a/examples/small-study/web-ext-config.js
+++ b/examples/small-study/web-ext-config.js
@@ -10,7 +10,7 @@ const defaultConfig = {
     overwriteDest: true,
   },
   run: {
-    firefox: "firefox",
+    firefox: "nightly",
     browserConsole: true,
     startUrl: ["about:debugging"],
     pref: ["shieldStudy.logLevel=All"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -273,7 +273,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
       "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3419,8 +3418,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-parse": {
       "version": "1.0.3",
@@ -3437,8 +3435,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5599,8 +5596,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -7840,8 +7836,7 @@
     "punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "qs": {
       "version": "6.5.2",
@@ -10291,7 +10286,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
       "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shield-studies-addon-utils",
-  "version": "5.0.1",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "@types/node": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
-      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.5.tgz",
+      "integrity": "sha512-6lRwZN0Y3TuglwaaZN2XPocobmzLlhxcqDjKFjNYSsXG/TFAGYkCqkzZh4+ms8iTHHQE6gJXLHPV7TziVGeWhg==",
       "dev": true
     },
     "JSONSelect": {
@@ -120,61 +120,50 @@
       }
     },
     "addons-linter": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-0.41.0.tgz",
-      "integrity": "sha512-jrN8OC6HKWv6nadJYOWH/ISiuJrTzBp0Jonfg7xUBPTSo6Lxo/EWBv1s3mSGTErzhiODDAFFsP6QUr76QwfcWA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-1.0.0.tgz",
+      "integrity": "sha512-6cC0Jcf0vMVgE86TV4A1lfjx78Fp0JltA1UH2icz/cALWMMfDZrD7YpB4dMrpobclsbKFPHexNOYhS4efAc5ng==",
       "dev": true,
       "requires": {
-        "ajv": "6.3.0",
+        "ajv": "6.5.0",
         "ajv-merge-patch": "3.0.0",
         "babel-register": "6.26.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "cheerio": "1.0.0-rc.2",
         "columnify": "1.5.4",
         "common-tags": "1.7.2",
         "crx-parser": "0.1.2",
         "deepmerge": "2.1.0",
-        "dispensary": "0.16.0",
+        "dispensary": "0.18.0",
         "doctoc": "1.3.1",
         "es6-promisify": "5.0.0",
-        "eslint": "4.19.0",
+        "eslint": "4.19.1",
         "eslint-plugin-no-unsafe-innerhtml": "1.0.16",
         "esprima": "3.1.3",
         "first-chunk-stream": "2.0.0",
-        "fluent-syntax": "^0.6.5",
+        "fluent-syntax": "^0.7.0",
         "glob": "7.1.2",
         "is-mergeable-object": "1.1.0",
         "jed": "1.1.1",
         "os-locale": "2.1.0",
-        "pino": "4.14.0",
+        "pino": "4.16.1",
         "po2json": "0.4.5",
         "postcss": "6.0.19",
         "probe-image-size": "4.0.0",
         "relaxed-json": "1.0.1",
         "semver": "5.5.0",
         "shelljs": "0.8.1",
-        "snyk": "^1.70.1",
-        "source-map-support": "0.5.4",
+        "snyk": "^1.78.1",
+        "source-map-support": "0.5.6",
         "strip-bom-stream": "3.0.0",
         "tosource": "1.0.0",
-        "upath": "1.0.4",
-        "whatwg-url": "6.3.0",
+        "upath": "1.0.5",
+        "whatwg-url": "6.4.1",
         "xmldom": "0.1.27",
         "yargs": "11.0.0",
         "yauzl": "2.9.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -185,9 +174,9 @@
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -195,85 +184,10 @@
             "supports-color": "^5.3.0"
           }
         },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "eslint": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
-          "integrity": "sha512-r83L5CuqaocDvfwdojbz68b6tCUk8KJkqfppO+gmSAQqYCzTr0bCSMu6A6yFCLKG65j5eKcKUw4Cw4Yl4gfWkg==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.3.0",
-            "babel-code-frame": "^6.22.0",
-            "chalk": "^2.1.0",
-            "concat-stream": "^1.6.0",
-            "cross-spawn": "^5.1.0",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^3.7.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^3.5.4",
-            "esquery": "^1.0.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.0.1",
-            "ignore": "^3.3.3",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^3.0.6",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.9.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^1.0.1",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.3.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "4.0.2",
-            "text-table": "~0.2.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-              "dev": true,
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-              }
-            }
-          }
-        },
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "shelljs": {
@@ -294,11 +208,12 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
+            "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
         },
@@ -310,6 +225,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "upath": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+          "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
+          "dev": true
         },
         "yargs": {
           "version": "11.0.0",
@@ -374,14 +295,6 @@
       "requires": {
         "fast-json-patch": "^1.0.0",
         "json-merge-patch": "^0.2.3"
-      },
-      "dependencies": {
-        "fast-json-patch": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-1.2.2.tgz",
-          "integrity": "sha1-03fZfGkR290qHIC/rNoEik+Du/k=",
-          "dev": true
-        }
       }
     },
     "alce": {
@@ -698,9 +611,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.4.tgz",
-      "integrity": "sha512-RbY3UMcOcGhc3pOfQ6sliVjt3lqGib9lRjfH1UXJ8YfBFWbcWSJ8jr/VB2W6ulCzTSO/DSnCASqsHYuqa8O7yw==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
       "dev": true
     },
     "async": {
@@ -2387,15 +2300,15 @@
       }
     },
     "dispensary": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.16.0.tgz",
-      "integrity": "sha1-cXPygoOAE148jrn2Fxn6A4wM0TM=",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.18.0.tgz",
+      "integrity": "sha512-ikVxjigcj4leoPgjqYcHV1YhmLEZ5eXMq30CIPTf1BniWrH1C0X35F5iVCa4U2/JXZYcQJyHWniSRSOpM+hiNw==",
       "dev": true,
       "requires": {
         "array-from": "~2.1.1",
         "async": "~2.6.0",
         "natural-compare-lite": "~1.4.0",
-        "pino": "~4.14.0",
+        "pino": "~4.16.1",
         "request": "~2.85.0",
         "semver": "~5.5.0",
         "sha.js": "~2.4.4",
@@ -2532,13 +2445,13 @@
       }
     },
     "dtrace-provider": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
-      "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.3"
+        "nan": "^2.10.0"
       }
     },
     "duplexer": {
@@ -2603,9 +2516,9 @@
       }
     },
     "email-validator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.3.tgz",
-      "integrity": "sha1-M+UNZvUmuXzXLBcgWu+ux5yKKh4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -2687,9 +2600,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -2793,9 +2706,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -2935,6 +2848,16 @@
         "eslint": "^3.7.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
         "ajv-keywords": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -3152,16 +3075,6 @@
             "string-width": "^2.0.0"
           },
           "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-              "dev": true,
-              "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
-              }
-            },
             "ansi-regex": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -3515,6 +3428,12 @@
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "dev": true
     },
+    "fast-json-patch": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-1.2.2.tgz",
+      "integrity": "sha1-03fZfGkR290qHIC/rNoEik+Du/k=",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3686,15 +3605,15 @@
       }
     },
     "flatstr": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.5.tgz",
-      "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.8.tgz",
+      "integrity": "sha512-YXblbv/vc1zuVVUtnKl1hPqqk7TalZCppnKE7Pr8FI/Rp48vzckS/4SJ4Y9O9RNiI82Vcw/FydmtqdQOg1Dpqw==",
       "dev": true
     },
     "fluent-syntax": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.6.6.tgz",
-      "integrity": "sha512-8iuHPWpn8pPt7/GOBcoDu+x34PkKOH7D0xIjq4C0K2tmf2Bo9bSYVlCj1kvv8g51xKInCyKYg6q5wb6cKZjdUA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.7.0.tgz",
+      "integrity": "sha512-T0iqfhC40jrs3aDjYOKgzIQjjhsH2Fa6LnXB6naPv0ymW3DeYMUFa89y9aLKMpi1P9nl2vEimK7blx4tVnUWBg==",
       "dev": true
     },
     "for-in": {
@@ -4422,13 +4341,13 @@
       "dev": true
     },
     "fx-runner": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.8.tgz",
-      "integrity": "sha1-XO07BKjVHWNN4g0UgPDcXdgyXew=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.9.tgz",
+      "integrity": "sha1-eyPzdz3HaqzELxHZr/J2lnXLY/A=",
       "dev": true,
       "requires": {
         "commander": "2.9.0",
-        "lodash": "3.10.1",
+        "lodash": "4.17.10",
         "shell-quote": "1.6.1",
         "spawn-sync": "1.0.15",
         "when": "3.7.7",
@@ -4449,12 +4368,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
           "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "which": {
@@ -5487,12 +5400,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5522,26 +5429,6 @@
       "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz",
       "integrity": "sha1-LPn7rkbYB0/Ba33gBxyO/rykc6Y=",
       "dev": true
-    },
-    "joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        }
-      }
     },
     "js-select": {
       "version": "0.6.0",
@@ -5763,22 +5650,27 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.1.9.tgz",
-      "integrity": "sha1-hHgE5SWL7FqUmajcSl56O64I1Yo=",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
       "dev": true,
       "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.3",
+        "jws": "^3.1.4",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^0.7.1",
+        "ms": "^2.1.1",
         "xtend": "^4.0.1"
       },
       "dependencies": {
         "ms": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
@@ -6198,6 +6090,42 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -6328,6 +6256,16 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "macos-release": {
       "version": "1.1.0",
@@ -6681,10 +6619,11 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
-      "dev": true
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true,
+      "optional": true
     },
     "moz-download-url": {
       "version": "2.0.0",
@@ -7225,12 +7164,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
-      "dev": true
-    },
     "opn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
@@ -7669,25 +7602,25 @@
       }
     },
     "pino": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-4.14.0.tgz",
-      "integrity": "sha512-nuPTxdy3OHmsdZmi8hzZYlW0m2+8HLUYM8euys6OOKVGBRF8TY7uFGvQZMLkwNgG+Zw+pNaGUw7OIMa76Ok2eg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-4.16.1.tgz",
+      "integrity": "sha512-ST/IC5RMyqrOZL+Hq6LDwz5h4fGKABXzx2/5Ze7rz5TjuPvE8uI72dzj409xkq9JjyWsKoOOApgXn8kEjJ73yg==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.2",
         "fast-json-parse": "^1.0.3",
         "fast-safe-stringify": "^1.2.3",
         "flatstr": "^1.0.5",
-        "pino-std-serializers": "^1.0.0",
+        "pino-std-serializers": "^2.0.0",
         "pump": "^3.0.0",
         "quick-format-unescaped": "^1.1.2",
         "split2": "^2.2.0"
       }
     },
     "pino-std-serializers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-1.2.0.tgz",
-      "integrity": "sha512-6LQcMXLHlT+PKMFkY6WpPmQvkFIecngF7WJPiMi5PfCGcScikvB3kt+Q5+zLtxw0dxPqXHd9XczPx/HwsNmOIA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.1.0.tgz",
+      "integrity": "sha512-NqWvrQD/GpY78ybiNBzi/dg8ylERhDo6nB33j5sfCKpUmWLc3lYzeoBjyRoCMvEpDpL9lmH6ufRd0jw6rcd1pQ==",
       "dev": true
     },
     "pluralize": {
@@ -7850,16 +7783,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
           }
         }
       }
@@ -8165,18 +8088,18 @@
       },
       "dependencies": {
         "deep-extend": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "rc": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -8194,18 +8117,18 @@
       },
       "dependencies": {
         "deep-extend": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "rc": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -8379,9 +8302,9 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -8491,9 +8414,9 @@
       "dev": true
     },
     "safe-json-stringify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.1.0.tgz",
-      "integrity": "sha512-EzBtUaFH9bHYPc69wqjp0efJI/DPNHdFbGE3uIMn4sVbO0zx8vZ8cG4WKxQfOpUOKsQyGBiT2mTqnCw+6nLswA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "dev": true,
       "optional": true
     },
@@ -8717,35 +8640,23 @@
       "integrity": "sha1-2yBiSamGlJkVnThHxxiYV1lfgM0="
     },
     "sign-addon": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/sign-addon/-/sign-addon-0.3.0.tgz",
-      "integrity": "sha512-xc9beD51s4OUaBIstN9xXfZMzEVqi9iYXbrOTDivxb3Z6+nSw/X4q6tXqqJ+QP0kyMzQxLTagnRroC5wWVH5mQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sign-addon/-/sign-addon-0.3.1.tgz",
+      "integrity": "sha512-feaoG7+8IXr9SymOEd8VTZCSlVZArWcBDZ33IIdfXlU5NWWzXdCxCjPDqAkLQplFa7RRZr1S4lSmgMPn80Ze1A==",
       "dev": true,
       "requires": {
         "babel-polyfill": "6.16.0",
         "deepcopy": "0.6.3",
         "es6-error": "4.0.0",
         "es6-promisify": "5.0.0",
-        "jsonwebtoken": "7.1.9",
+        "jsonwebtoken": "8.2.1",
         "mz": "2.5.0",
-        "request": "2.79.0",
+        "request": "2.87.0",
         "source-map-support": "0.4.6",
         "stream-to-promise": "2.2.0",
         "when": "3.7.7"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
         "babel-polyfill": {
           "version": "6.16.0",
           "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
@@ -8757,100 +8668,11 @@
             "regenerator-runtime": "^0.9.5"
           }
         },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
         "es6-error": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.0.tgz",
           "integrity": "sha1-8JTHBB9mJZm7EnINoFnWucf/D0A=",
           "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
         },
         "mz": {
           "version": "2.5.0",
@@ -8863,12 +8685,6 @@
             "thenify-all": "^1.0.0"
           }
         },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.9.6",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
@@ -8876,40 +8692,31 @@
           "dev": true
         },
         "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
             "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
+            "extend": "~3.0.1",
             "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
             "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "source-map-support": {
@@ -8920,21 +8727,6 @@
           "requires": {
             "source-map": "^0.5.3"
           }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
         },
         "uuid": {
           "version": "3.2.1",
@@ -9092,9 +8884,9 @@
       }
     },
     "snyk": {
-      "version": "1.80.1",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.80.1.tgz",
-      "integrity": "sha1-+S0f6oKDOjmmB1mPhH4mmfAzvlw=",
+      "version": "1.83.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.83.0.tgz",
+      "integrity": "sha1-IH+y9HMGcZ9iZk0tLo6AeylLrqA=",
       "dev": true,
       "requires": {
         "abbrev": "^1.1.1",
@@ -9113,19 +8905,19 @@
         "recursive-readdir": "^2.2.2",
         "semver": "^5.5.0",
         "snyk-config": "2.1.0",
-        "snyk-go-plugin": "1.5.0",
+        "snyk-go-plugin": "1.5.1",
         "snyk-gradle-plugin": "1.3.0",
         "snyk-module": "1.8.2",
         "snyk-mvn-plugin": "1.2.0",
         "snyk-nuget-plugin": "1.6.2",
         "snyk-php-plugin": "1.5.1",
         "snyk-policy": "1.12.0",
-        "snyk-python-plugin": "1.6.0",
+        "snyk-python-plugin": "1.6.1",
         "snyk-resolve": "1.0.1",
         "snyk-resolve-deps": "3.1.0",
         "snyk-sbt-plugin": "1.3.0",
         "snyk-tree": "^1.0.0",
-        "snyk-try-require": "1.3.0",
+        "snyk-try-require": "1.3.1",
         "tempfile": "^2.0.0",
         "then-fs": "^2.0.0",
         "undefsafe": "^2.0.0",
@@ -9171,12 +8963,13 @@
       }
     },
     "snyk-go-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.0.tgz",
-      "integrity": "sha512-H6CHhGqchCcQV/JhOiSbTI8JLYhQU7dZ/oLwHMfVEXSD3bWOp1evlohuaQQaqic/ZInitLsjkCLHG2x47ZgUgQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.1.tgz",
+      "integrity": "sha512-8OPJOT05Z/UL5fFSXV6b/A6KjlS1Ahr2gpup1bhXtAGXlUUPyWidqkCIER9fexDXqYWgAoDAdn9YHIvmL/5bfw==",
       "dev": true,
       "requires": {
         "graphlib": "^2.1.1",
+        "tmp": "0.0.33",
         "toml": "^2.3.2"
       }
     },
@@ -9297,10 +9090,13 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.6.0.tgz",
-      "integrity": "sha512-/9PcO6lvSY62qGpFjrRQ00NQdUulZnit6tOLMZp+91BnOjoiw4aKKr7uoky6rbwu64fEmK3sE+tcp8BXqH9kDQ==",
-      "dev": true
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.6.1.tgz",
+      "integrity": "sha512-6zr5jAB3p/bwMZQxZpdj+aPmioTgHB4DI6JMLInhZupss0x8Ome5YqzVzBbOvUKNrc3KaLtjGrJWcAuxDL6M/g==",
+      "dev": true,
+      "requires": {
+        "tmp": "0.0.33"
+      }
     },
     "snyk-resolve": {
       "version": "1.0.1",
@@ -9353,16 +9149,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
         }
       }
     },
@@ -9385,9 +9171,9 @@
       }
     },
     "snyk-try-require": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.0.tgz",
-      "integrity": "sha1-81cGrPkciveI1Y4fGta/D89sVJM=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
+      "integrity": "sha1-bgJvkuZK9/zM6h7lPVJIQeQYohI=",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -9403,16 +9189,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
           }
         }
       }
@@ -9561,9 +9337,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -9573,6 +9349,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -10141,23 +9918,6 @@
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
       "dev": true
     },
-    "topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        }
-      }
-    },
     "tosource": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tosource/-/tosource-1.0.0.tgz",
@@ -10687,15 +10447,15 @@
       }
     },
     "web-ext": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-2.6.0.tgz",
-      "integrity": "sha1-UsB0Ej5jdqT7Zz5WXDPdAncU6bA=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-2.7.0.tgz",
+      "integrity": "sha512-hXj/MV/x6G0oxplOirV4/j7BJ5MZJ2yZHml0gulBr7mH2BMNyTJHdRi+qzVBNPFdBMLV0/PS05YGZ7xr2YmwVA==",
       "dev": true,
       "requires": {
         "@cliqz-oss/firefox-client": "0.3.1",
         "@cliqz-oss/node-firefox-connect": "1.2.1",
         "adbkit": "2.11.0",
-        "addons-linter": "0.41.0",
+        "addons-linter": "1.0.0",
         "babel-polyfill": "6.26.0",
         "babel-runtime": "6.26.0",
         "bunyan": "1.8.12",
@@ -10706,17 +10466,17 @@
         "es6-promisify": "5.0.0",
         "event-to-promise": "0.8.0",
         "firefox-profile": "1.1.0",
-        "fx-runner": "1.0.8",
+        "fx-runner": "1.0.9",
         "git-rev-sync": "1.9.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "mz": "2.7.0",
         "node-notifier": "5.2.1",
-        "open": "0.0.5",
+        "opn": "5.3.0",
         "parse-json": "4.0.0",
         "regenerator-runtime": "0.11.1",
         "require-uncached": "1.0.3",
-        "sign-addon": "0.3.0",
+        "sign-addon": "0.3.1",
         "source-map-support": "0.5.3",
         "stream-to-promise": "2.2.0",
         "strip-json-comments": "2.0.1",
@@ -10897,14 +10657,14 @@
       }
     },
     "whatwg-url": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz",
-      "integrity": "sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.0",
-        "webidl-conversions": "^4.0.1"
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "when": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-mozilla": "^0.13.0",
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "fixpack": "^2.3.1",
-    "fx-runner": "^1.0.7",
+    "fx-runner": "^1.0.9",
     "geckodriver": "^1.11.0",
     "get-firefox": "^2.1.0",
     "mocha": "^5.2.0",
@@ -31,7 +31,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.11.0",
     "selenium-webdriver": "^3.6.0",
-    "web-ext": "^2.5.0",
+    "web-ext": "^2.7.0",
     "webpack": "^2.6.1",
     "yamljs": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "test-addon": "cd test-addon && web-ext run --no-reload",
     "test-addon:build": "cd test-addon && web-ext build",
     "test-addon:bundle-utils": "./bin/copyStudyUtils.js test-addon/src/privileged",
-    "test-only": "FIREFOX_BINARY=${FIREFOX_BINARY:-firefox} ADDON_ZIP=test-addon/dist/shield_utils_test_add-on-1.0.0.zip mocha test/functional/ --bail"
+    "test-only": "FIREFOX_BINARY=${FIREFOX_BINARY:-nightly} ADDON_ZIP=test-addon/dist/shield_utils_test_add-on-1.0.0.zip mocha test/functional/ --bail"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shield-studies-addon-utils",
   "description": "Utilities for building Shield-Study Mozilla Firefox add-ons.",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "Mozilla",
   "bin": {
     "copyStudyUtils": "bin/copyStudyUtils.js"

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "url": "https://github.com/mozilla/shield-studies-addon-utils/issues"
   },
   "dependencies": {
+    "ajv": "^6.5.0",
     "commander": "^2.15.1",
     "fs-extra": "^6.0.1",
     "shield-study-schemas": "^0.8.3"
   },
   "devDependencies": {
-    "ajv": "^6.5.0",
     "assert": "^1.4.1",
     "doctoc": "^1.3.1",
     "eslint": "4.19.1",

--- a/test-addon/src/studySetup.js
+++ b/test-addon/src/studySetup.js
@@ -42,9 +42,7 @@ const baseStudySetup = {
       ],
     },
     ineligible: {
-      baseUrls: [
-        "https://qsurvey.mozilla.com/s3/Shield-Study-Example-Survey/?reason=ineligible",
-      ],
+      baseUrls: [],
     },
     expired: {
       baseUrls: [

--- a/test-addon/src/studySetup.js
+++ b/test-addon/src/studySetup.js
@@ -104,8 +104,8 @@ const baseStudySetup = {
  */
 async function cachingFirstRunShouldAllowEnroll() {
   // Cached answer.  Used on 2nd run
-  let allowed = await browser.storage.local.get("allowEnroll");
-  if (allowed.allowEnroll === true) return true;
+  let allowed = await browser.storage.local.get("allowedEnrollOnFirstRun");
+  if (allowed.allowedEnrollOnFirstRun === true) return true;
 
   /*
   First run, we must calculate the answer.
@@ -116,7 +116,7 @@ async function cachingFirstRunShouldAllowEnroll() {
   allowed = true;
 
   // cache the answer
-  await browser.storage.local.set({ allowEnroll: allowed });
+  await browser.storage.local.set({ allowedEnrollOnFirstRun: allowed });
   return allowed;
 }
 

--- a/test-addon/src/studySetup.js
+++ b/test-addon/src/studySetup.js
@@ -105,7 +105,7 @@ const baseStudySetup = {
 async function cachingFirstRunShouldAllowEnroll() {
   // Cached answer.  Used on 2nd run
   let allowed = await browser.storage.local.get("allowEnroll");
-  if (allowed) return true;
+  if (allowed.allowEnroll === true) return true;
 
   /*
   First run, we must calculate the answer.

--- a/test-addon/web-ext-config.js
+++ b/test-addon/web-ext-config.js
@@ -10,7 +10,7 @@ const defaultConfig = {
     overwriteDest: true,
   },
   run: {
-    firefox: "firefox",
+    firefox: "nightly",
     browserConsole: true,
     startUrl: ["about:debugging"],
     pref: ["shieldStudy.logLevel=All"],

--- a/test/functional/browser.study.api.js
+++ b/test/functional/browser.study.api.js
@@ -773,6 +773,113 @@ describe("PUBLIC API `browser.study` (not specific to any add-on background logi
       });
     });
 
+    describe("setup of an ineligible study should result in endStudy('ineligible') without even emitting onReady", function() {
+      let endingResult;
+      const overrides = {
+        activeExperimentName: "test:browser.study.api",
+        telemetry: {
+          send: true,
+          removeTestingFlag: false,
+        },
+        endings: {
+          ineligible: {
+            baseUrls: [],
+          },
+        },
+        allowEnroll: false,
+        testing: {},
+      };
+
+      before(async function reinstallSetupAndAwaitEndStudy() {
+        await reinstallAddon();
+        endingResult = await addonExec(
+          async (_studySetupForTests, callback) => {
+            // Ensure we have a configured study and are supposed to run our feature
+            browser.study.onEndStudy.addListener(async _endingResult => {
+              console.log(
+                "In resetSetupAndAwaitEndStudy - onEndStudy listener",
+                _endingResult,
+              );
+              callback(_endingResult);
+            });
+            browser.study.onReady.addListener(async _studyInfo => {
+              console.log(
+                "In resetSetupAndAwaitEndStudy - onReady listener",
+                _studyInfo,
+              );
+              throw new Error(
+                "onReady should not have been emitted",
+                _studyInfo,
+              );
+            });
+            await browser.study.setup(_studySetupForTests);
+          },
+          studySetupForTests(overrides),
+        );
+      });
+
+      describe("browser.study.endStudy() side effects", function() {
+        it("should have fired onEndStudy event with the endingResult", function() {
+          // console.debug(full(endingResult));
+          assert(endingResult);
+          assert.strictEqual(endingResult.endingName, "ineligible");
+          assert.strictEqual(endingResult.queryArgs.fullreason, "ineligible");
+          assert(endingResult.shouldUninstall);
+          assert.strictEqual(
+            endingResult.urls.length,
+            0,
+            "the ending should have the expected number of urls configured",
+          );
+        });
+
+        it("should have set the experiment as inactive", async () => {
+          const activeExperiments = await utils.telemetry.getActiveExperiments(
+            driver,
+          );
+          assert(
+            !activeExperiments.hasOwnProperty(overrides.activeExperimentName),
+          );
+        });
+
+        describe("should have sent the expected exit telemetry", function() {
+          let studyPings;
+
+          before(async () => {
+            studyPings = await utils.telemetry.searchSentTelemetry(driver, {
+              type: ["shield-study", "shield-study-addon"],
+            });
+            // For debugging tests
+            // console.debug(full(studyPings.map(x => [x.type, x.payload])));
+            // console.debug("Final pings report: ", utils.telemetry.pingsReport(studyPings));
+          });
+
+          it("one shield-study telemetry ping with study_state=exit", async () => {
+            const filteredPings = studyPings.filter(
+              ping =>
+                ping.type === "shield-study" &&
+                ping.payload.data.study_state === "exit",
+            );
+            assert(
+              filteredPings.length > 0,
+              "at least one shield-study telemetry ping with study_state=exit",
+            );
+          });
+
+          it("one shield-study telemetry ping with study_state=ineligible", async () => {
+            const filteredPings = studyPings.filter(
+              ping =>
+                ping.type === "shield-study" &&
+                ping.payload.data.study_state === "ineligible",
+            );
+            assert(
+              filteredPings.length > 0,
+              "at least one shield-study telemetry ping with study_state=ineligible",
+            );
+          });
+        });
+      });
+    });
+
     describe("setup of an already expired study should result in endStudy('expired') without even emitting onReady", function() {
       let endingResult;
       const overrides = {

--- a/test/functional/browser.study.api.js
+++ b/test/functional/browser.study.api.js
@@ -499,7 +499,7 @@ describe("PUBLIC API `browser.study` (not specific to any add-on background logi
       );
     });
 
-    it("6. testing.firstRunTimestamp override works as expected", async function() {
+    it("6a. testing.firstRunTimestamp override can be set to an integer", async function() {
       // console.debug("doing test 6");
       const thisSetup = studySetupForTests({
         testing: {
@@ -518,6 +518,29 @@ describe("PUBLIC API `browser.study` (not specific to any add-on background logi
       assert.strictEqual(
         info.firstRunTimestamp,
         123,
+        "should be the same as our override",
+      );
+    });
+
+    it("6b. testing.firstRunTimestamp override can be set to 0", async function() {
+      // console.debug("doing test 6");
+      const thisSetup = studySetupForTests({
+        testing: {
+          firstRunTimestamp: 0,
+        },
+      });
+      const data = await addonExec(async (setup, cb) => {
+        // this is what runs in the webExtension scope.
+        const info = await browser.study.setup(setup);
+        const internals = await browser.studyDebug.getInternals();
+        // call back with all the data we care about to Mocha / node
+        cb({ info, internals });
+      }, thisSetup);
+      // console.debug(full(data));
+      const { info } = data;
+      assert.strictEqual(
+        info.firstRunTimestamp,
+        0,
         "should be the same as our override",
       );
     });

--- a/webExtensionApis/study/src/index.js
+++ b/webExtensionApis/study/src/index.js
@@ -17,7 +17,10 @@ logger.debug("loading web extension experiment study/api.js");
 // eslint-disable-next-line no-undef
 const { EventManager } = ExtensionCommon;
 // eslint-disable-next-line no-undef
-const { EventEmitter, ExtensionError } = ExtensionUtils;
+const { ExtensionError } = ExtensionUtils;
+
+const EventEmitter =
+  ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter;
 
 /** Event emitter to handle Events defined in the API
  *

--- a/webExtensionApis/study/src/studyUtils.js
+++ b/webExtensionApis/study/src/studyUtils.js
@@ -344,12 +344,17 @@ class StudyUtils {
    * @returns {any} the firstRunTimestamp as a number in case the preference is set, or null if the preference is not set
    */
   getFirstRunTimestamp() {
-    const firstRunTimestampPreferenceValue =
-      this._internals.studySetup.testing.firstRunTimestamp ||
-      Services.prefs.getStringPref(
-        this._internals.prefs.firstRunTimestamp,
-        null,
-      );
+    if (
+      typeof this._internals.studySetup.testing.firstRunTimestamp !==
+        "undefined" &&
+      this._internals.studySetup.testing.firstRunTimestamp !== null
+    ) {
+      return Number(this._internals.studySetup.testing.firstRunTimestamp);
+    }
+    const firstRunTimestampPreferenceValue = Services.prefs.getStringPref(
+      this._internals.prefs.firstRunTimestamp,
+      null,
+    );
     return firstRunTimestampPreferenceValue !== null
       ? Number(firstRunTimestampPreferenceValue)
       : null;

--- a/weeUtils/generateStubApi.js
+++ b/weeUtils/generateStubApi.js
@@ -14,7 +14,7 @@ ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
 // eslint-disable-next-line no-undef
 const { EventManager } = ExtensionCommon;
 // eslint-disable-next-line no-undef
-const { EventEmitter } = ExtensionUtils;
+const EventEmitter = ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter
 `;
 
 function schema2fakeApi(schemaApiJSON) {


### PR DESCRIPTION
Collaborative PR to land 5.0.3 with clean-ups, smaller improvements and critical fixes without introducing any backwards incompatible changes to the API.

To use this release candidate in your add-on: `npm install mozilla/shield-studies-addon-utils#release/5.0.3 --save`

Restored CI tests with latest fx nightly versions (including fix for #228 via https://github.com/mozilla/shield-studies-addon-utils/pull/229)