### PR TITLE
Import EventEmitter differently depending on version

### DIFF
--- a/webExtensionApis/study/src/index.js
+++ b/webExtensionApis/study/src/index.js
@@ -19,7 +19,8 @@ const { EventManager } = ExtensionCommon;
 // eslint-disable-next-line no-undef
 const { ExtensionError } = ExtensionUtils;
 
-const EventEmitter = ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter
+const EventEmitter =
+  ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter;
 
 /** Event emitter to handle Events defined in the API
  *

--- a/webExtensionApis/study/src/index.js
+++ b/webExtensionApis/study/src/index.js
@@ -17,7 +17,9 @@ logger.debug("loading web extension experiment study/api.js");
 // eslint-disable-next-line no-undef
 const { EventManager } = ExtensionCommon;
 // eslint-disable-next-line no-undef
-const { EventEmitter, ExtensionError } = ExtensionUtils;
+const { ExtensionError } = ExtensionUtils;
+
+const EventEmitter = ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter
 
 /** Event emitter to handle Events defined in the API
  *

--- a/weeUtils/generateStubApi.js
+++ b/weeUtils/generateStubApi.js
@@ -14,7 +14,7 @@ ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
 // eslint-disable-next-line no-undef
 const { EventManager } = ExtensionCommon;
 // eslint-disable-next-line no-undef
-const { EventEmitter } = ExtensionUtils;
+const EventEmitter = ExtensionCommon.EventEmitter || ExtensionUtils.EventEmitter
 `;
 
 function schema2fakeApi(schemaApiJSON) {


### PR DESCRIPTION
This PR fixes #228.
Currently the study library in this repo is broken in Nightly because [`EventEmitter` was moved from `ExtensionUtils` to `ExtensionCommon`](https://bugzilla.mozilla.org/show_bug.cgi?id=1471102).

This is a small change that checks if `EventEmitter` could be imported from `ExtensionCommon` and otherwise imports it from `ExtensionUtils`.
The build process does not work for me, so I'm not sure if this actually fixes everything. Maybe other imports have to be changed, too. But at least the `EventEmitter` import works properly for me in Nightly and Beta like this.