### PR TITLE
Revert "Fix links to API docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Allows writing [Shield and Pioneer](https://wiki.mozilla.org/Firefox/Shield/Shie
 
 ### `browser.study.*`
 
-[`browser.study` API documentation](./docs/webExtensionApis/study/api.md)
+[`browser.study` API documentation](./docs/study/api.md)
 
 Provides these capabilities:
 
@@ -132,7 +132,7 @@ Depending on which data processing pipeline the study add-on is configured to us
 
 ### `browser.studyDebug.*`
 
-[`browser.studyDebug` API documentation](./docs/webExtensionApis/study/api.md)
+[`browser.studyDebug` API documentation](./docs/study/api.md)
 
 Tools for writing tests, getting and resetting StudyUtils iternals.
 


### PR DESCRIPTION
Reverts mozilla/shield-studies-addon-utils#261

(Sorry for merging this too quickly, the new links were broken)