### PR TITLE
Add normandy unenroll listener

### DIFF
--- a/examples/small-study/src/studySetup.js
+++ b/examples/small-study/src/studySetup.js
@@ -37,7 +37,31 @@ const baseStudySetup = {
 
   // endings with urls
   endings: {
-    /** standard endings */
+    /** normandy-defined endings - https://firefox-source-docs.mozilla.org/toolkit/components/normandy/normandy/data-collection.html */
+    "install-failure": {
+      baseUrls: [],
+    },
+    "individual-opt-out": {
+      baseUrls: [
+        "https://qsurvey.mozilla.com/s3/Shield-Study-Example-Survey/?reason=individual-opt-out",
+      ],
+    },
+    "general-opt-out": {
+      baseUrls: [],
+    },
+    "recipe-not-seen": {
+      baseUrls: [],
+    },
+    uninstalled: {
+      baseUrls: [],
+    },
+    "uninstalled-sideload": {
+      baseUrls: [],
+    },
+    unknown: {
+      baseUrls: [],
+    },
+    /** study-utils-defined endings */
     "user-disable": {
       baseUrls: [
         "https://qsurvey.mozilla.com/s3/Shield-Study-Example-Survey/?reason=user-disable",

--- a/webExtensionApis/study/src/index.js
+++ b/webExtensionApis/study/src/index.js
@@ -109,10 +109,17 @@ this.study = class extends ExtensionAPI {
     const addonLogger = createLogger(widgetId, `shieldStudy.logLevel`);
 
     async function endStudy(anEndingAlias) {
-      utilsLogger.debug("called endStudy anEndingAlias");
+      utilsLogger.debug("called endStudy with anEndingAlias:", anEndingAlias);
       const endingResponse = await studyUtils.endStudy(anEndingAlias);
       studyApiEventEmitter.emitEndStudy(endingResponse);
     }
+
+    // Add normandy unenroll listener
+    const { AddonStudies } = ChromeUtils.import(
+      "resource://normandy/lib/AddonStudies.jsm",
+      {},
+    );
+    AddonStudies.addUnenrollListener(extension.id, reason => endStudy(reason));
 
     return {
       study: {

--- a/webExtensionApis/study/src/studyUtils.js
+++ b/webExtensionApis/study/src/studyUtils.js
@@ -561,7 +561,18 @@ class StudyUtils {
     this.throwIfNotSetup("endStudy");
 
     // also handle default endings.
-    const alwaysHandle = ["ineligible", "expired", "user-disable"];
+    const alwaysHandle = [
+      "ineligible",
+      "expired",
+      "user-disable",
+      "install-failure",
+      "individual-opt-out",
+      "general-opt-out",
+      "recipe-not-seen",
+      "uninstalled",
+      "uninstalled-sideload",
+      "unknown",
+    ];
     let ending = this._internals.studySetup.endings[endingName];
     if (!ending) {
       // a 'no-action' ending is okay for the 'always handle'


### PR DESCRIPTION
- [x] Make onEndStudy fire upon Normandy unenrollment
- [ ] Make sure that the Promise returned to Normandy resolves only when onEndStudy is finished executing

Automatic tests (which could be modeled after https://searchfox.org/mozilla-central/source/toolkit/components/normandy/test/unit/test_addon_unenroll.js) have been omitted since this is merely a stop-gap fix to support study add-ons until study utils are added to tree. 

Please review and advice on how we can test this manually. 

Fixes 1 out of 2 outstanding issues outlined in https://github.com/mozilla/shield-studies-addon-utils/issues/246
Fixes https://github.com/mozilla/shield-studies-addon-utils/issues/267
Fixes #154