### PR TITLE
Make sure the example add-on does not show in about:addons

### DIFF
--- a/examples/small-study/src/manifest.json
+++ b/examples/small-study/src/manifest.json
@@ -3,6 +3,7 @@
   "description": "Demo of shield-studies-addon-utils",
   "version": "1.0.0",
   "manifest_version": 2,
+  "hidden": true,
   "applications": {
     "gecko": {
       "id": "shield-utils-small-study-demo@shield.mozilla.org",


### PR DESCRIPTION
Analogous to https://github.com/mozilla/shield-studies-addon-template/pull/98/commits/694a547ae0e1d5dc31672eb33b9e43120ca3f51f

Fixes 1 out of 2 outstanding issues outlined in https://github.com/mozilla/shield-studies-addon-utils/issues/246
Fixes #247, since the study can no longer be disabled by the user from about:addons