### PR TITLE
Add browser.study.fullSurveyUrl

### DIFF
--- a/test/functional/browser.study.api.js
+++ b/test/functional/browser.study.api.js
@@ -323,12 +323,22 @@ function publicApiTests(studyType) {
           _caughtErrors.push(e.toString());
         }
 
+        try {
+          await browser.study.fullSurveyUrl(
+            "https://foo.com/survey-foo/",
+            "mid-study-survey",
+          );
+        } catch (e) {
+          _caughtErrors.push(e.toString());
+        }
+
         callback(_caughtErrors);
       });
       const expected = [
         "Error: endStudy: this method can't be used until `setup` is called",
         "Error: telemetry: this method can't be used until `setup` is called",
         "Error: info: this method can't be used until `setup` is called",
+        "Error: endingQueryArgs: this method can't be used until `setup` is called",
       ];
       assert.deepStrictEqual(caughtErrors, expected);
     });
@@ -1357,19 +1367,33 @@ function publicApiTests(studyType) {
     });
   });
 
-  // TODO 5.2+
-  describe.skip("possible 5.2+ future tests.", function() {
-    describe("uninstall by users?", function() {});
-
-    describe("surveyUrl", function() {
-      describe("needs setup", function() {
-        it("throws StudyNotSetupError  if not setup");
-      });
-      describe("correctly constructs urls queryArgs from profile info", function() {
-        it("an example url is correct");
+  describe("api: fullSurveyUrl", function() {
+    describe("correctly constructs urls queryArgs", function() {
+      it("an example url is correct", async function() {
+        const actual = await addonExec(async callback => {
+          const result = await browser.study.fullSurveyUrl(
+            "https://foo.com/survey-foo/",
+            "mid-study-survey",
+          );
+          callback(result);
+        });
+        const matchesExpectedExceptForTheClientId =
+          actual.indexOf(
+            "https://foo.com/survey-foo/?shield=3&study=test%3Abrowser.study.api&variation=control&updateChannel=nightly&fxVersion=67.0a1&addon=1.0.0&who=",
+          ) > -1 &&
+          actual.indexOf(
+            "&testing=1&reason=mid-study-survey&fullreason=mid-study-survey",
+          ) > -1;
+        assert(matchesExpectedExceptForTheClientId);
       });
     });
-    describe.skip("log", function() {
+  });
+
+  // TODO 5.3+
+  describe.skip("possible 5.3+ future tests.", function() {
+    describe("uninstall by users - individual opt-out", function() {});
+
+    describe.skip("browser.study.logger", function() {
       it("log level works?");
     });
   });

--- a/webExtensionApis/study/api.md
+++ b/webExtensionApis/study/api.md
@@ -239,6 +239,23 @@ Using AJV, do jsonschema validation of an object. Can be used to validate your a
   * $ref:
   * optional: false
 
+### `browser.study.fullSurveyUrl( surveyBaseUrl, reason )`
+
+Annotates the supplied survey base url with common survey parameters (study name, variation, updateChannel, fxVersion, add-on version and client id)
+
+**Parameters**
+
+* `surveyBaseUrl`
+
+  * type: surveyBaseUrl
+  * $ref:
+  * optional: false
+
+* `reason`
+  * type: reason
+  * $ref:
+  * optional: false
+
 ## Events
 
 ### `browser.study.onReady ()` Event

--- a/webExtensionApis/study/schema.json
+++ b/webExtensionApis/study/schema.json
@@ -734,6 +734,24 @@
             "descripton": "a valid jsonschema object",
             "additionalProperties": true
           }
+        ]
+      },
+      {
+        "name": "fullSurveyUrl",
+        "type": "function",
+        "async": true,
+        "defaultReturn": "https://foo.com/?reason=foo&addon=1.0.0",
+        "description":
+          "Annotates the supplied survey base url with common survey parameters (study name, variation, updateChannel, fxVersion, add-on version and client id)",
+        "parameters": [
+          {
+            "name": "surveyBaseUrl",
+            "type": "string"
+          },
+          {
+            "name": "reason",
+            "type": "string"
+          }
         ],
         "returns": [
           {

--- a/webExtensionApis/study/schema.yaml
+++ b/webExtensionApis/study/schema.yaml
@@ -546,6 +546,17 @@
       descripton: a valid jsonschema object
       additionalProperties: true
 
+  - name: fullSurveyUrl
+    type: function
+    async: true
+    defaultReturn: "https://foo.com/?reason=foo&addon=1.0.0"
+    description: Annotates the supplied survey base url with common survey parameters (study name, variation, updateChannel, fxVersion, add-on version and client id)
+    parameters:
+    - name: surveyBaseUrl
+      type: string
+    - name: reason
+      type: string
+
     # aValidation
     returns:
     - type: object

--- a/webExtensionApis/study/src/index.js
+++ b/webExtensionApis/study/src/index.js
@@ -368,6 +368,16 @@ this.study = class extends ExtensionAPI {
           // return { valid: true, errors: [] };
         },
 
+        /* Annotates the supplied survey base url with common survey parameters (study name, variation, updateChannel, fxVersion, add-on version and client id) */
+        fullSurveyUrl: async function fullSurveyUrl(surveyBaseUrl, reason) {
+          utilsLogger.debug(
+            "Called fullSurveyUrl(surveyBaseUrl, reason)",
+            surveyBaseUrl,
+            reason,
+          );
+          return studyUtils.fullSurveyUrl(surveyBaseUrl, reason);
+        },
+
         /* Returns an object with the following keys:
     variationName - to be able to test specific variations
     firstRunTimestamp - to be able to test the expiration event

--- a/webExtensionApis/study/src/studyUtils.js
+++ b/webExtensionApis/study/src/studyUtils.js
@@ -660,6 +660,13 @@ class StudyUtils {
     return out;
   }
 
+  async fullSurveyUrl(surveyBaseUrl, reason) {
+    const queryArgs = await this.endingQueryArgs();
+    queryArgs.reason = reason;
+    queryArgs.fullreason = reason;
+    return mergeQueryArgs(surveyBaseUrl, queryArgs);
+  }
+
   /**
    * Builds an object whose properties are query arguments that can be
    * appended to a study ending url


### PR DESCRIPTION
Relevant to be able to fire mid-study surveys with the same query arguments as ending surveys.